### PR TITLE
add Angelo to supporters list

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@
                   <a href="https://twitter.com/johnhering" target="_blank">John Hering</a>, Jeff Cordova,
                   <a href="https://twitter.com/nalidoust" target="_blank">Nima Alidoust</a>,
                   <a href="https://www.ornl.gov/staff-profile/travis-s-humble" target="_blank">Travis Humble</a>, George
-                  Umbrarescu, Michał Stęchły, Terrill Frantz, 
+                  Umbrarescu, Michał Stęchły, Terrill Frantz,
                   <a href="https://jordanrule.com" target="_blank">Jordan Rule</a>,
                   <a href="https://www.zapatacomputing.com/team/greg-ramsay/" target="_blank">Greg Ramsay</a>,
                   <a href="https://www.zapatacomputing.com/team/peter-johnson/" target="_blank">Peter Johnson</a>,
@@ -224,6 +224,7 @@
                   <a href="https://www.linkedin.com/in/amirebrahimi/" target="_blank">Amir Ebrahimi</a>,
                   <a href="https://sites.northwestern.edu/koch/" target="_blank">Jens Koch</a>,
                   <a href="https://www.linkedin.com/in/christophe-jurczak" target="_blank">Christophe Jurczak</a>,
+                  <a href="https://www.linkedin.com/in/angelo-danducci" target="_blank">Angelo Danducci II</a>,
                   <a href="https://twitter.com/wjzeng" target="_blank">Will Zeng</a>
                 </li>
               </ul>


### PR DESCRIPTION
@AngeloDanducci has kindly asked us to donate their [unitaryHACK bounty](https://unitaryhack.dev/hackers/angelodanducci/) back to Unitary Fund. Adding them on our main page where we list all supporters.