### PR TITLE
Add image upload and blog edit information

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To add an image in a page, there are two options:
 1. (**No Code option**): Go to https://unitary-fund.vercel.app/author/image and upload your desired image. 
  Copy the code it returns after upload and use such and such syntax to insert. (e.g, d394zg4utwqxynenamqf). Note that this option is the required one for adding a cover image to a new `event`.
 
-2. Upload the image under `public/images/` + embed image links in markdown files e.g., ![(images/image.png), and embed it into the desired page, e.g., using the `![alt text](/images/your_image.png)` syntax.
+2. Upload the image to `public/images/` and embed it into the desired page using the `![alt text](/images/your_image.png)` syntax.
 
 ## Adding a new grant
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This is a standard paragraph with a [hyperlink](https://www.example.com). **This
 
 - this is a list item
 - this is **bold** list item
-- this is a long list item which has lots of words in it and will probably break onto a second or even a third line so we can see how that looks at differnt sizes adn make sure it looks as it is intended too
+- this is a long list item which has lots of words in it and will probably break onto a second or even a third line so we can make sure it looks as it is intended too. Can even have multiple sentences within a list item.
 - this is a list item with a [LINK](https://www.google.com) or [two)](https://www.google.com) added in it. 
 
 ### This is a heading in heading style three introducing a video

--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ https://www.youtube.com/watch?v=dB_3R84ewig
 
 
 ## Including code snippets with gists
-A supported way to include code snippets is by embedding gists. Gists are code snippets that you can create on Github. Make sure that they are public. For example, navigating to [gist.github.com/matt-lourens/](https://gist.github.com/matt-lourens/) one can click on one of the gists and obtain the url  https://gist.github.com/matt-lourens/6cc14d37209de07abd707804f1b0219e. In order to embed the related code in the blog post, you can do one of the following:
+A supported way to include code snippets is by embedding gists.
+Gists are code snippets that you can create on Github.
+Learn how to create one [here](https://docs.github.com/en/get-started/writing-on-github/editing-and-sharing-content-with-gists/creating-gists), and don't forget to ensure it is public!
+Once created, use the hash from the gist URL with the syntax below.
 
 
 ::gist[matt-lourens/6cc14d37209de07abd707804f1b0219e/]

--- a/README.md
+++ b/README.md
@@ -30,16 +30,50 @@ month: 2
 year: 2023
 ---
 
-your markdown content
+# This is a heading style one
+
+**This is a featured Paragraph it cannot contain bold text but can contain [links](https://www.unitary.fund).**
+
+More text
+
+::image[d394zg4utwqxynenamqf]
+
+## This is a heading in heading style two
+
+This is a standard paragraph with a [LINK](https://www.google.com). **This is bold paragraph text**
+
+- this is a list item
+- this is **bold** list item
+- this is a long list item which has lots of words in it and will probably break onto a second or even a third line so we can see how that looks at differnt sizes adn make sure it looks as it is intended too
+- this is a list item with a [LINK](https://www.google.com) or [two)](https://www.google.com) added in it. 
+
+### This is a heading in heading style three introducing a video
+
+https://www.youtube.com/watch?v=dB_3R84ewig
+
+#### This is a heading in heading style four
+
+::gist[6cc14d37209de07abd707804f1b0219e]
+
+With slashes
+
+::gist[matt-lourens/6cc14d37209de07abd707804f1b0219e/]
+
+::gist[/matt-lourens//6cc14d37209de07abd707804f1b0219e/]
 ```
 
 Once your post is ready, open a pull request (PR)!
+
 The Vercel automation will create a preview you can access by clicking the "Visit preview" link that shows up in the bot comment.
 If the changes look good, request a review by tagging one of the UF team members (e.g., `@nathanshammah`).
 
-### Adding images to a blog post
+## Adding images
 
-To add an image in a document, upload the image to `public/images/`, and embed it into the desired page using the `![alt text](/images/your_image.png)` syntax.
+To add an image in a page, there are two options:
+
+1. (**No Code option**): Go to https://unitary-fund.vercel.app/author/image + copy the code (e..g, d394zg4utwqxynenamqf) + paste it in the markdown file as "::image[d394zg4utwqxynenamqf]". This option is the one required for adding the cover image to a new `event`.
+
+2. Upload the image under `public/images/` + embed image links in markdown files e.g., ![(images/image.png), and embed it into the desired page, e.g., using the `![alt text](/images/your_image.png)` syntax.
 
 ## Adding a new grant
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ If the changes look good, request a review by tagging one of the UF team members
 
 To add an image in a page, there are two options:
 
-1. (**No Code option**): Go to https://unitary-fund.vercel.app/author/image + copy the code (e..g, d394zg4utwqxynenamqf) + paste it in the markdown file as "::image[d394zg4utwqxynenamqf]". This option is the one required for adding the cover image to a new `event`.
+1. (**No Code option**): Go to https://unitary-fund.vercel.app/author/image and upload your desired image. 
+ Copy the code it returns after upload and use such and such syntax to insert. (e.g, d394zg4utwqxynenamqf). Note that this option is the required one for adding a cover image to a new `event`.
 
 2. Upload the image under `public/images/` + embed image links in markdown files e.g., ![(images/image.png), and embed it into the desired page, e.g., using the `![alt text](/images/your_image.png)` syntax.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If the changes look good, request a review by tagging one of the UF team members
 To add an image in a page, there are two options:
 
 1. (**No Code option**): Go to https://unitary-fund.vercel.app/author/image and upload your desired image. 
- Copy the code it returns after upload and use such and such syntax to insert. (e.g, d394zg4utwqxynenamqf). Note that this option is the required one for adding a cover image to a new `event`.
+ Copy the code it returns after upload, e.g, d394zg4utwqxynenamqf, and use the syntax `::image[d394zg4utwqxynenamqf]` to insert it. Note that this option is the required one for adding a cover image to a new `event`.
 
 2. Upload the image to `public/images/` and embed it into the desired page using the `![alt text](/images/your_image.png)` syntax.
 

--- a/README.md
+++ b/README.md
@@ -53,13 +53,15 @@ https://www.youtube.com/watch?v=dB_3R84ewig
 
 #### This is a heading in heading style four
 
+
+## Including code snippets with gists
+A supported way to include code snippets is by embedding gists. Gists are code snippets that you can create on Github. Make sure that they are public. For example, navigating to [gist.github.com/matt-lourens/](https://gist.github.com/matt-lourens/) one can click on one of the gists and obtain the url  https://gist.github.com/matt-lourens/6cc14d37209de07abd707804f1b0219e. In order to embed the related code in the blog post, you can do one of the following:
+
 ::gist[6cc14d37209de07abd707804f1b0219e]
 
-With slashes
+or with slashes
 
 ::gist[matt-lourens/6cc14d37209de07abd707804f1b0219e/]
-
-::gist[/matt-lourens//6cc14d37209de07abd707804f1b0219e/]
 ```
 
 Once your post is ready, open a pull request (PR)!

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ More text
 
 ## This is a heading in heading style two
 
-This is a standard paragraph with a [LINK](https://www.google.com). **This is bold paragraph text**
+This is a standard paragraph with a [hyperlink](https://www.example.com). **This is bold paragraph text**.
 
 - this is a list item
 - this is **bold** list item

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This is a standard paragraph with a [hyperlink](https://www.example.com). **This
 - this is a list item
 - this is **bold** list item
 - this is a long list item which has lots of words in it and will probably break onto a second or even a third line so we can make sure it looks as it is intended too. Can even have multiple sentences within a list item.
-- this is a list item with a [LINK](https://www.google.com) or [two)](https://www.google.com) added in it. 
+- this is a list item with a [link](https://unitaryhack.dev/) added in it. 
 
 ### This is a heading in heading style three introducing a video
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,6 @@ https://www.youtube.com/watch?v=dB_3R84ewig
 ## Including code snippets with gists
 A supported way to include code snippets is by embedding gists. Gists are code snippets that you can create on Github. Make sure that they are public. For example, navigating to [gist.github.com/matt-lourens/](https://gist.github.com/matt-lourens/) one can click on one of the gists and obtain the url  https://gist.github.com/matt-lourens/6cc14d37209de07abd707804f1b0219e. In order to embed the related code in the blog post, you can do one of the following:
 
-::gist[6cc14d37209de07abd707804f1b0219e]
-
-or with slashes
 
 ::gist[matt-lourens/6cc14d37209de07abd707804f1b0219e/]
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ year: 2023
 
 # This is a heading style one
 
-**This is a featured Paragraph it cannot contain bold text but can contain [links](https://www.unitary.fund).**
+**This is a featured paragraph it cannot contain bold text but can contain [links](https://www.unitary.fund).**
 
 More text
 


### PR DESCRIPTION
Add image upload and blog edit information to the readme. Include both ways an image can be added. Include information on typography in blog posts, including adding code snippets as a `gist`.