### PR TITLE
Add Kallie and Farrokh to team

### DIFF
--- a/src/content/team/main.json
+++ b/src/content/team/main.json
@@ -5,6 +5,14 @@
       "url": "https://www.linkedin.com/in/ben-castanon-96526a14/"
     },
     {
+      "title": "Kallie Ferguson",
+      "url": "https://www.linkedin.com/in/kallieferguson"
+    },
+    {
+      "title": "Farrokh Labib",
+      "url": "https://linkedin.com/in/farrokh-labib-13066687"
+    },
+    {
       "title": "Andrea Mari",
       "url": "https://sites.google.com/site/andreamari84/"
     },


### PR DESCRIPTION
Add Kallie and Farrokh to team on homepage.

@KallieFerguson and @FarLab please let me know if you prefer another link than your personal linkedin account (or no link at all).