### PR TITLE
Fix Filter Placement on Mobile When Scrolling

### DIFF
--- a/src/components/Filter/Filters.tsx
+++ b/src/components/Filter/Filters.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react';
-import { useContext } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { FilterContext } from '~/components/Filter/FilterContextProvider';
 import { FilterRenderer } from '~/components/Filter/Renderer/FilterRenderer';
 import { Button } from '~/components/Ui/Form/Button';
@@ -8,6 +8,11 @@ import { cn } from '~/util/cn';
 import { FilterMode, filterMap, filterModeAtom } from '~/util/store';
 
 export function Filters() {
+  // Values come from /src/styles/base/_variables.scss and are used to prevent a top-gap in the filter
+  // when scrolling on mobile
+  const logoHeightMobilePx = 57 // from /src/styles/base/_variables.scss
+  const scrollThreshold = Math.ceil(logoHeightMobilePx * 0.64);
+
   const filterContext = useContext(FilterContext);
 
   if (!filterContext) {
@@ -17,6 +22,7 @@ export function Filters() {
   const { filterKeys } = filterContext;
 
   const filterMode = useStore(filterModeAtom);
+  const [fixToTop, setFixToTop] = useState(false);
 
   const handleClearClick = () => {
     filterMap.set({});
@@ -30,9 +36,24 @@ export function Filters() {
     }
   };
 
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollDistance = window.scrollY || document.documentElement.scrollTop;
+      setFixToTop(scrollDistance >= scrollThreshold);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+  }, []);
+
+  const getCorrectFilterClassForMobile = () => {
+    return fixToTop ?
+        "md:hidden flex flex-col fixed top-0 w-full left-0 z-30" :
+        "md:hidden flex flex-col fixed top-[--navigation-trigger-height-mobile] w-full left-0 z-30"
+  }
+
   return (
     <>
-      <div className="md:hidden flex flex-col fixed top-[--navigation-trigger-height-mobile] w-full left-0 z-30">
+      <div className={getCorrectFilterClassForMobile()}>
         <div className="flex border-b border-b-black">
           <Button
             variant="base"


### PR DESCRIPTION
Fixes #363

## Affected Pages
* Blog
* Grants

## Summary of Changes
MR changes the behavior of the filter on the mobile version of the page. When the user scrolls far enough that the header is no longer visible, the filter will move to the top of the screen and stay there. If the user scrolls back to the top, the filter will move back down so the header is visible.

The drawback of this approach is that a gap remains visible for the short scroll portion (37 pixels) closest to the top. However, it is a  simple approach that should not affect website performance on older devices as much as a pixel-by-pixel change would.

## New Behavior:
After scrolling:
![Screenshot_20240223_065330](https://github.com/unitaryfund/unitary.fund/assets/20098360/568152a2-5fc6-4778-a635-040d6033c73c) 
![Screenshot_20240223_065926](https://github.com/unitaryfund/unitary.fund/assets/20098360/3076f5d7-7db5-4b4a-9e17-9269b8774271)

While on top:
![Screenshot_20240223_065550](https://github.com/unitaryfund/unitary.fund/assets/20098360/ca4a4d90-ae08-4793-b993-2f23af3286e9)


## Old Behavior (unchanged for top 37 pixels):
Visible Gap:
![Screenshot_20240223_065444](https://github.com/unitaryfund/unitary.fund/assets/20098360/1c484aab-0a64-4cdc-bf82-8d26648d28e0)
