### PR TITLE
Solve small bug in adding_qibo code

### DIFF
--- a/src/content/blog/adding_qibo.md
+++ b/src/content/blog/adding_qibo.md
@@ -64,7 +64,7 @@ def executor(circuit, shots = 1000):
     
     result = noisy_c(nshots=shots)
     result_freq = result.frequencies(binary=True)
-    counts_0 = result_freq.get(0)
+    counts_0 = result_freq.get('0')
     if counts_0 is None:
         expectation_value = 0.
     else:


### PR DESCRIPTION
@nathanshammah I've noticed a small error along with @natestemen in https://github.com/unitaryfund/mitiq/pull/2220 in the code provided in the tutorial on the blog post about adding Qibo. The code functions correctly when using older versions of Qibo, such as 0.2.0 (which happened to be the version I had installed on my computer without realizing it), but it doesn't produce the correct result with newer versions of Qibo.
If modifying the blog post is as easy as accepting the pull it would be nice to update the blog post with this small change. If modifying an existing blog post is a big deal then don't worry the overall intention of the tutorial remains valid. 