### PR TITLE
Update grant tags

### DIFF
--- a/src/content/grant/2018_NISQAI.md
+++ b/src/content/grant/2018_NISQAI.md
@@ -7,6 +7,5 @@ country: US
 tags:
   - python
   - machine learning
-  - quantum
 ---
 To the [NISQAI](https://github.com/QuantumAI-lib/NISQAI) project to build a library for machine learning with near-term quantum processors. [Proposal](https://github.com/QuantumAI-lib/NISQAI/blob/master/proposal/nisqai.pdf), [Video](https://www.youtube.com/watch?v=_dOJ7Bhibec&t=1s), [arXiv](https://scirate.com/arxiv/2003.01695), [publ.](https://link.aps.org/doi/10.1103/PhysRevA.102.032420)

--- a/src/content/grant/2018_QAOA_Traveling_Salesman.md
+++ b/src/content/grant/2018_QAOA_Traveling_Salesman.md
@@ -4,8 +4,9 @@ year: 2018
 month: 6
 day: 27
 country: PL
-tags: 
-  - quantum education
+tags:
+  - education
   - python
+  - qaoa
 ---
 To [Michał Stęchły](http://www.mustythoughts.com/about/) to build a traveling salesman solver web application and [tutorials](https://github.com/mstechly/quantum_tsp_tutorials) for Forest based on the quantum approximate optimization algorithm. [github tutorials](https://github.com/mstechly/quantum_tsp_tutorials), [blogpost](https://www.mustythoughts.com/post/solving-the-traveling-salesman-problem-using-quantum-computer), [web app source code (it's not live anymore)](https://github.com/BOHRTECHNOLOGY/tsp-demo-unitary-fund)

--- a/src/content/grant/2018_QCGPU.md
+++ b/src/content/grant/2018_QCGPU.md
@@ -6,6 +6,6 @@ day: 2
 tags:
   - GPU
   - python
-  - quantum
+  - simulator
 ---
  To [Adam Kelly](https://adamisntdead.com/) to extend his work on the open source [QCGPU](https://qcgpu.github.io/) high performance quantum circuit simulator [github](https://github.com/QCGPU/qcgpu), [libraries](https://github.com/libtangle), [website](https://libtangle.com/).

--- a/src/content/grant/2018_Quantum_programming_studio.md
+++ b/src/content/grant/2018_Quantum_programming_studio.md
@@ -6,7 +6,6 @@ day: 15
 country: RS
 tags:
   - python
-  - quantum
   - simulator
 ---
 To [Petar Korponaić](https://github.com/perak) to support and extend the [Quantum Programming Studio](https://quantum-circuit.com/home), an open source in-browser IDE for multi-platform quantum programming. This project became the startup [Quantastica](https://quantastica.com/) that makes cross-platform quantum software. [Twitter](https://twitter.com/quantcirc), [Website](https://quantum-circuit.com/)

--- a/src/content/grant/2018_Qurry.md
+++ b/src/content/grant/2018_Qurry.md
@@ -5,8 +5,7 @@ month: 6
 day: 26
 country: US
 tags:
-  - probability
-  - python
-  - TeX
+  - programming language
+  - probabilistic programming
 ---
 To [Lucas Saldyt](https://github.com/LSaldyt) to prototype a [probabilistic programming language for quantum computing](https://github.com/LSaldyt/unitary-proposal). This library is called [Qurry](https://github.com/LSaldyt/qurry).

--- a/src/content/grant/2018_pyZX.md
+++ b/src/content/grant/2018_pyZX.md
@@ -6,7 +6,7 @@ day: 9
 country: NL
 tags:
   - python
-  - OpenQasm
-  - visualization
+  - compiler
+  - pyzx
 ---
 To [Aleks Kissinger](https://www.cs.ru.nl/A.Kissinger/) and [John van de Wetering](http://vdwetering.name/) to support the development of [pyZX](https://github.com/Quantomatic/pyzx), an optimizing quantum circuit compiler based on a diagrammatic semantics from monoidal categories. This work resulted in two publications: (i) an overview of the pyZX library and (ii) benchmarks showing that pyZX outperforms the state of the art in reducing T-Count. [arXiv1](https://arxiv.org/abs/1904.04735) [arXiv2](https://arxiv.org/pdf/1903.10477.pdf) [Video](https://www.youtube.com/watch?v=iC-KVdB8pf0) [Website](http://zxcalculus.com/)

--- a/src/content/grant/2019_Interactive_in-browser_ket_and_matrix_viewers.md
+++ b/src/content/grant/2019_Interactive_in-browser_ket_and_matrix_viewers.md
@@ -5,7 +5,7 @@ month: 12
 day: 21
 country: PL
 tags:
-  - quantum education
+  - education
   - visualization
   - game
 ---

--- a/src/content/grant/2019_QHyp.md
+++ b/src/content/grant/2019_QHyp.md
@@ -5,7 +5,6 @@ month: 10
 day: 13
 country: AU
 tags:
-  - quantum
-  - software
+  - probabilistic programming
 ---
 To [Abdul Karim Obeid](https://www.linkedin.com/in/abdulko/) and the [QHyp](https://qhyp.info/) project, developing research and software at the intersection of quantum contextuality and probabilistic programming.  [Publication](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0208555)

--- a/src/content/grant/2019_QWorld's_QCousins.md
+++ b/src/content/grant/2019_QWorld's_QCousins.md
@@ -4,8 +4,8 @@ year: 2019
 month: 10
 day: 21
 country: HU, LV, PL
-tags: 
-  - quantum education
-  - software
+tags:
+  - education
+  - workshop
 ---
 To [QCousins](http://qworld.lu.lv/index.php/qcousins/) to support their mission of welcoming a young and diverse group of programmers into quantum computing. The grant will fund more of their quantum programming [workshops](http://qworld.lu.lv/index.php/workshop-bronze/) and [educational materials](http://qworld.lu.lv/index.php/qkitchen/). [Workshops we funded](http://qworld.lu.lv/index.php/unitary-fund/)

--- a/src/content/grant/2019_Qrack.md
+++ b/src/content/grant/2019_Qrack.md
@@ -7,7 +7,6 @@ country: US
 tags:
   - simulator
   - C++
-  - quantum
   - GPU
 ---
 To [Qrack](https://github.com/vm6502q/qrack) an open source, comprehensive, GPU-accelerated framework for simulating universal quantum processors. (Qrack has also passed the proof-of-concept stage for distributed simulation.) [Docs](https://qrack.readthedocs.io/en/latest/index.html), [Benchmarks](https://qrack.readthedocs.io/en/latest/performance.html)

--- a/src/content/grant/2019_QuNetSim.md
+++ b/src/content/grant/2019_QuNetSim.md
@@ -8,5 +8,7 @@ tags:
   - simulator
   - python
   - cryptography
+  - networks
+  - qutip
 ---
 To [Stephen DiAdamo](https://scholar.google.ca/citations?user=k9O1vSwAAAAJ&hl=en) to develop [QuNetSim](https://arxiv.org/abs/2003.06397), a quantum network Python simulation framework for investigating quantum network protocols. [github](https://github.com/tqsd/QuNetSim), [arXiv](https://arxiv.org/abs/2003.06397), [video](https://www.youtube.com/watch?v=HE6jWjW1WT8)

--- a/src/content/grant/2019_SciGym.md
+++ b/src/content/grant/2019_SciGym.md
@@ -5,7 +5,7 @@ month: 1
 day: 28
 country: AT
 tags:
-  - Machine Learning
-  - quantum
+  - machine learning
+  - error correction
 ---
 To [SciGym](https://www.scigym.net/) to build open source library for reinforcement learning environments in science. Examples include [training a surface code decoder.](https://www.scigym.net/env/gym-surfacecode)

--- a/src/content/grant/2019_zxQentiana.md
+++ b/src/content/grant/2019_zxQentiana.md
@@ -6,7 +6,9 @@ day: 4
 country: AT, CH
 tags:
   - Javascript
-  - quantum
-  - visualizations
+  - error correction
+  - resource estimation
+  - visualization
+  - pyzx
 ---
 To [Alexandru Paler](https://scholar.google.com/citations?user=WmghO7UAAAAJ) and [Daniel Herr](https://scholar.google.com/citations?user=80srjkkAAAAJ&hl=en) to develop zxQentiana an open source, resource estimator for time and space tradeoffs for the surface code that uses pyZX compilation. [github](https://github.com/quantumresource/zxQentiana)

--- a/src/content/grant/2020_Building_Quantum_RAM_in_Qsharp.md
+++ b/src/content/grant/2020_Building_Quantum_RAM_in_Qsharp.md
@@ -6,6 +6,6 @@ day: 23
 country: US, CA
 tags:
   - Q#
-  - microsoft
+  - programming language
 ---
 To [Olivia De Matteo](http://glassnotes.github.io/) and [Sarah Kaiser](https://www.sckaiser.com/) to build and optimize an open source Q# library for quantum RAM. [github](https://github.com/qsharp-community/qram)

--- a/src/content/grant/2020_Establishing_QWorld.md
+++ b/src/content/grant/2020_Establishing_QWorld.md
@@ -5,7 +5,7 @@ month: 10
 day: 5
 country: LV
 tags:
-  - quantum education
+  - education
   - non-profit
 ---
 To the [QWorld](https://qworld.lu.lv/), team, a follow-up grant to be incorporated as a non-profit organization and step up their activities.  [arXiv](https://arxiv.org/abs/2010.13552)

--- a/src/content/grant/2020_ML-powered_ QAOA_Util.md
+++ b/src/content/grant/2020_ML-powered_ QAOA_Util.md
@@ -6,7 +6,7 @@ day: 1
 country: PL
 tags:
   - python
-  - Machine Learning
-  - QAOA
+  - machine learning
+  - qaoa
 ---
 To [Dariusz Lasecki](https://dlasecki.github.io/) to build an open-source Python library that delivers easy-to-use high-quality pre-trained machine learning models to predict good QAOA starting parameters for selected classes of problems.

--- a/src/content/grant/2020_MartaCT.md
+++ b/src/content/grant/2020_MartaCT.md
@@ -1,12 +1,12 @@
 ---
-name: "Marta CT" 
+name: "Marta CT"
 year: 2020
 month: 11
 day: 2
 country: IT
 tags:
-  - medical 
-  - quantum
-  - software
+  - medical
+  - julia
+  - quantum inspired
 ---
 To **Nicola Mosco**, to develop [Marta CT](https://gitlab.com/homodyne-ct/MartaCT.jl), a software package in Julia for medical diagnostics that uses a quantum-tomography-inspired technique for state reconstruction in order to reduce the radiation dose patients receive. [arXiv](https://arxiv.org/abs/2106.12353)

--- a/src/content/grant/2020_QAOA_Library.md
+++ b/src/content/grant/2020_QAOA_Library.md
@@ -5,7 +5,8 @@ month: 3
 day: 24
 country: PL
 tags:
-  - quantum algorithm
+  - algorithm
   - Q#
+  - qaoa
 ---
 To [Dariusz Lasecki](https://dlasecki.github.io/) to build an open source QAOA library and examples using Q#.

--- a/src/content/grant/2020_QRand.md
+++ b/src/content/grant/2020_QRand.md
@@ -6,6 +6,7 @@ day: 5
 country: ES, US
 tags:
   - python
-  - quantum
+  - probabilistic programming
+  - numpy
 ---
 To **Pedro Rivero Ramírez** for [QRand](https://github.com/pedrorrivero/qrand/), a multi-platform quantum random number generator library integrated with numpy.

--- a/src/content/grant/2020_Quantum_Machine_Learning_Textbook.md
+++ b/src/content/grant/2020_Quantum_Machine_Learning_Textbook.md
@@ -1,11 +1,12 @@
 ---
-name: Quantum Machine Learning Textbook 
+name: Quantum Machine Learning Textbook
 year: 2020
 month: 11
 day: 16
 country: IN
 tags:
-  - QML
-  - quantum education
+  - machine learning
+  - education
+  - textbook
 ---
 To [Rochisha Agarwal](https://rochisha0.github.io/) and [Natansh Mathur](https://www.linkedin.com/in/natanshmathur/) to create a [Machine Learning Textbook](https://github.com/Quantum-Machine-Learning-Textbook/Book) with integrated code and visualization.

--- a/src/content/grant/2020_Quantum_Medical_Imaging.md
+++ b/src/content/grant/2020_Quantum_Medical_Imaging.md
@@ -1,11 +1,10 @@
 ---
-name: Quantum Medical Imaging 
+name: Quantum Medical Imaging
 year: 2020
 month: 9
 day: 20
 country: GB
 tags:
   - medical
-  - quantum
 ---
 To [Mark Cunningham](https://markcunningham.tech/) to explore applications of quantum computing to medical imaging.

--- a/src/content/grant/2020_Quantum_Tales.md
+++ b/src/content/grant/2020_Quantum_Tales.md
@@ -5,7 +5,8 @@ month: 9
 day: 21
 country: US
 tags:
-  - quantum education
-  - quantum algorithm
+  - education
+  - algorithm
+  - textbook
 ---
 To [Spencer Churchill](https://github.com/splch) to write [Quantum Tales](https://quantumtales.org/), a series of fairy tales where quantum algorithms are applied to resolve their conflicts.

--- a/src/content/grant/2020_Qubit_by_Qubit.md
+++ b/src/content/grant/2020_Qubit_by_Qubit.md
@@ -3,6 +3,7 @@ name: Qubit by Qubit
 year: 2020
 country: US
 tags:
-  - quantum education
+  - education
+  - workshop
 ---
 To the team at [Qubit By Qubit](https://www.qubitbyqubit.org/), to develop courses and materials to educate a diverse ecosystem of open source quantum contributors.

--- a/src/content/grant/2020_Toqito.md
+++ b/src/content/grant/2020_Toqito.md
@@ -6,7 +6,7 @@ day: 16
 country: CA
 tags:
   - python
-  - ganes
-  - quantum
+  - games
+  - toqito
 ---
 To [Vincent Russo](https://vprusso.github.io/) to support [toqito](https://vprusso.github.io/toqito/), an open source Python toolkit for quantum information theory with extra functionality to study non-local games. [software](https://github.com/vprusso/toqito), [paper](https://joss.theoj.org/papers/10.21105/joss.03082), [video](https://www.youtube.com/watch?v=6R7qSszJwBI)

--- a/src/content/grant/2020_TorchMP5.md
+++ b/src/content/grant/2020_TorchMP5.md
@@ -6,5 +6,6 @@ day: 16
 country: US
 tags:
   - python
+  - machine learning
 ---
 To [Jacob Miller](http://jemisjoky.com/) for a PyTorch toolbox for matrix product state models.

--- a/src/content/grant/2020_Yao_Group.md
+++ b/src/content/grant/2020_Yao_Group.md
@@ -1,10 +1,10 @@
 ---
-name: Yao Group 
+name: Yao Group
 year: 2020
 month: 5
 day: 15
 country: HK
 tags:
-  - quantum
+  - internship
 ---
 To [Muhammad Usman Farooq](https://github.com/usmanmunara/) for a research internship in the [Yao group](http://penghuiyao.info/) that lost funding due to the COVID crisis. They aim to construct a quantum channel with a Classical input Reverse Information Cost of zero.

--- a/src/content/grant/2020_fullstackquantumcomputation_tech.md
+++ b/src/content/grant/2020_fullstackquantumcomputation_tech.md
@@ -5,6 +5,6 @@ month: 7
 day: 15
 country: US
 tags:
-  - quantum education
+  - education
 ---
 To [Lia Yeh](https://www.linkedin.com/in/lia-yeh) and the [fullstackquantumcomputation.tech](https://fullstackquantumcomputation.tech/) team to build community-driven open-source educational resources for quantum computing. [site](https://fullstackquantumcomputation.tech/), [discord](https://discord.com/invite/NDm9e9W)

--- a/src/content/grant/2021_2QAN.md
+++ b/src/content/grant/2021_2QAN.md
@@ -5,8 +5,7 @@ month: 12
 day: 8
 country: GB
 tags:
-  - Hamiltonian
-  - Quantum
+  - hamiltonian
   - compiler
   - optmization
 ---

--- a/src/content/grant/2021_Heisenberg-picture_simulator..md
+++ b/src/content/grant/2021_Heisenberg-picture_simulator..md
@@ -1,11 +1,10 @@
 ---
-name: "Heisenberg-picture simulator" 
+name: "Heisenberg-picture simulator"
 year: 2021
 month: 10
 day: 25
 country: US
 tags:
   -  simulator
-  -  quantum
 ---
 To [Hoang Van Do](https://twitter.com/rmjh94), [Elie Gouzien](http://www.normalesup.org/~gouzien/), and [Saesun Kim](https://twitter.com/saesunkim) to develop a Heisenberg-picture simulator and universal gate set for high dimensional systems.

--- a/src/content/grant/2021_Improving_VQA_performance.md
+++ b/src/content/grant/2021_Improving_VQA_performance.md
@@ -6,6 +6,6 @@ day: 14
 country: US
 tags:
   - VQA
-  - quantum
+  - error mitigation
 ---
 To [Danny Samuel](https://www.linkedin.com/in/danny-samuel-9a8a621ba/) to improve and extend the performance of variational quantum algorithms with error mitigation, benchmarking them with mirror circuits.

--- a/src/content/grant/2021_InterlinQ.md
+++ b/src/content/grant/2021_InterlinQ.md
@@ -7,6 +7,7 @@ country: DE
 tags:
   - simulator
   - python
-  - quantum
+  - follow-up grant
+  - networks
 ---
 To [Rhea Parekh](https://twitter.com/RheaParekh1) and [Stephen DiAdamo](https://scholar.google.ca/citations?user=k9O1vSwAAAAJ&hl=en) to further develop [Interlin-q](https://github.com/Interlin-q/Interlin-q/), a distributed quantum-enabled simulator integrated with QuNetSim. [arXiv](https://arxiv.org/abs/2106.06841), [blog post](https://medium.com/@stephen.diadamo/distributed-quantum-computing-1c5d38a34c50)

--- a/src/content/grant/2021_Know_your_limits.md
+++ b/src/content/grant/2021_Know_your_limits.md
@@ -6,6 +6,8 @@ day: 15
 country: DK
 tags:
   - software
-  - quantum 
+  - qaoa
+  - optimization
+  - benchmarking
 ---
 To [Daniel Stilck França](https://twitter.com/dsfranca) to develop a software package that will help benchmark the limitations of noisy quantum devices for solving optimization problems. [arXiv](https://arxiv.org/pdf/2009.05532.pdf),  [QIP talk on the technique](https://www.youtube.com/watch?v=00ULKjGu1-A).

--- a/src/content/grant/2021_Krylov_&_K-GRAPE_algorithms.md
+++ b/src/content/grant/2021_Krylov_&_K-GRAPE_algorithms.md
@@ -6,7 +6,6 @@ day: 22
 country: AR
 tags:
   - python
-  - Krylov
-  - quantum
+  - qutip
 ---
 To **Diego Ariel Wisniacki, Martin Larocca, Emiliano Manuel Fortes, Julian Matias Ruffinelli** to develop Krylov evolution algorithms integrated with QuTiP. [K-GRAPE](https://arxiv.org/abs/2010.03598), [Krylov-Loschmidt](https://arxiv.org/abs/2107.09805). It is hosted at [GitHub](https://github.com/emilianomfortes/krylovsolver), and explained on [Medium](https://medium.com/@julian.ruffinelli/krylov-approximation-method-for-quantum-evolution-148b3f023ec4).

--- a/src/content/grant/2021_Lattice_surgery_QEC.md
+++ b/src/content/grant/2021_Lattice_surgery_QEC.md
@@ -1,13 +1,13 @@
 ---
-name: "Lattice surgery QEC" 
+name: "Lattice surgery QEC"
 year: 2021
 month: 10
 day: 13
 country: CA
 tags:
-  - QEC
   - python
   - compiler
+  - error correction
 ---
 
 To **George Watkins**, **Alex Nguyen**, **Varun Seshadri**, and **Keelan Watkins** to further develop a [lattice-surgery-based](https://github.com/latticesurgery-com/lattice-surgery-compiler) quantum error correction compiler. Demo at [latticesurgery.com](https://latticesurgery.com/)

--- a/src/content/grant/2021_QCourse511.md
+++ b/src/content/grant/2021_QCourse511.md
@@ -1,11 +1,11 @@
 ---
-name: QCourse511 
+name: QCourse511
 year: 2021
 month: 10
 day: 13
 country: LV
 tags:
-  - quantum education
+  - education
   - python
 ---
  To **Abuzer Yakaryilmaz** and the **[QWorld](https://twitter.com/qworld19)** team to organize [QCourse511](https://qworld.net/qcourse511-1/), a graduate-level online course on quantum computing and programming.

--- a/src/content/grant/2021_Qdot.md
+++ b/src/content/grant/2021_Qdot.md
@@ -5,7 +5,7 @@ month: 8
 day: 23
 country: GB
 tags:
-  - scala 
-  - quantum
+  - scala
+  - compiler
 ---
 To **Brian Shi** to build [Qdot](https://github.com/brs96/Qdot), a Scala 3 library (QASM-transpiler) that allows Scala/Java developers write native quantum/hybrid programs.

--- a/src/content/grant/2021_Quantify_Core.md
+++ b/src/content/grant/2021_Quantify_Core.md
@@ -6,6 +6,6 @@ day: 26
 country: NL
 tags:
   - python
-  - experiments 
+  - open hardware
 ---
 To the teams at Orange Quantum Systems and Qblox, to develop [Quantify Core](https://quantify-quantify-core.readthedocs-hosted.com/en/stable/), an open-source Python-based data acquisition and experiment control platform for quantum computing and solid-state physics experiments. It is built on [QCoDeS](https://qcodes.github.io/Qcodes/) and is a spiritual successor of [PycQED](https://github.com/DiCarloLab-Delft/PycQED_py3).

--- a/src/content/grant/2021_Quantum_algorithms.md
+++ b/src/content/grant/2021_Quantum_algorithms.md
@@ -5,8 +5,9 @@ month: 3
 day: 10
 country: SG
 tags:
-  - quantum education
-  - quantum algorithm
+  - education
+  - quantum algorithms
   - machine learning
+  - texbook
 ---
 To **Alessandro Luongo** and **Armando Bellante** to develop [Quantumalgorithms.org](https://quantumalgorithms.org/) an open-source web book collecting in an organized manner lectures notes around quantum algorithms for information processing, data analysis and machine learning.

--- a/src/content/grant/2021_Reinforcement_Learning_for_Quantum_Optimization.md
+++ b/src/content/grant/2021_Reinforcement_Learning_for_Quantum_Optimization.md
@@ -6,7 +6,8 @@ day: 22
 country: US
 tags:
   - python
-  - QML
-  - software
+  - machine learning
+  - optimization
+  - simulator
 ---
 To [Owen Lockwood](https://github.com/lockwo) to develop a software package using classical deep reinforcement learning to improve quantum optimization, both for quantum simulations and hardware integration.

--- a/src/content/grant/2021_SQWalk.md
+++ b/src/content/grant/2021_SQWalk.md
@@ -5,8 +5,9 @@ month: 4
 day: 26
 country: IT
 tags:
-  - simulator
   - python
-  - quantum
+  - simulator
+  - quantum walks
+  - qutip
 ---
 To **Lorenzo Buffoni**, to develop [SQWalk](https://github.com/Buffoni/SQWalk), A Stochastic Quantum Walk simulator based on QuTiP.

--- a/src/content/grant/2021_TEMPO_features.md
+++ b/src/content/grant/2021_TEMPO_features.md
@@ -1,12 +1,13 @@
 ---
-name: "TEMPO Features" 
+name: "TEMPO Features"
 year: 2021
 month: 9
 day: 27
 country: GB
 tags:
+   - python
   - simulator
-  - quantum
-  - python
+  - physics
+  - tensor networks
 ---
 To [Gerald E. Fux](https://twitter.com/fuxgerald) and Dominic Gribben and the [TEMPO collaboration](https://github.com/tempoCollaboration/TimeEvolvingMPO) to develop an open source python package for simulating non-Markovian open quantum systems using tensor network techniques. In particular, the grant will enable adding two new features: studying the role of environment correlation functions through observables of the system and of multiple environments coupled to a single system.

--- a/src/content/grant/2021_VQA_in_QuTip.md
+++ b/src/content/grant/2021_VQA_in_QuTip.md
@@ -1,5 +1,5 @@
 ---
-name: VQA in QuTip 
+name: VQA in QuTip
 year: 2021
 month: 11
 day: 10
@@ -7,5 +7,6 @@ country: AU
 tags:
   - quantum algorithm
   - VQA
+  - qutip
 ---
 To [Ben Braham](https://benbraham.com/), to develop a framework to define and run variational quantum algorithms in QuTiP, leveraging quantum optimal control to parametrize control pulses.

--- a/src/content/grant/2021_VeriFodo.md
+++ b/src/content/grant/2021_VeriFodo.md
@@ -5,8 +5,7 @@ month: 3
 day: 10
 country: CA
 tags:
-  -  C
+  -  c
   -  cryptography
-  -  quantum
 ---
 To [Goutam Tamvada](https://github.com/xvzcf) and [Douglas Stebila](https://www.douglas.stebila.ca/) to develop VeriFrodo, an open-source package implementing a lattice-based quantum-resistant cryptographic algorithms in Jasmin within the [Open Quantum Safe](https://github.com/open-quantum-safe) project.

--- a/src/content/grant/2021_debug_in_Qsharp.md
+++ b/src/content/grant/2021_debug_in_Qsharp.md
@@ -1,5 +1,5 @@
 ---
-name: "%debug in Q#" 
+name: "%debug in Q#"
 year: 2021
 month: 3
 day: 22
@@ -7,5 +7,6 @@ country: US
 tags:
   - Q#
   - visualization
+  - debugger
 ---
 To **Reem Larabi** to add more visualization improvements to the %debug tool in Q# by expanding its current set of controls.

--- a/src/content/grant/2021_pyALF.md
+++ b/src/content/grant/2021_pyALF.md
@@ -6,7 +6,6 @@ day: 26
 country: DE
 tags:
   - python
-  - quantum
   - simulation
   - fermion
 ---

--- a/src/content/grant/2021_qLEET.md
+++ b/src/content/grant/2021_qLEET.md
@@ -5,8 +5,8 @@ month: 9
 day: 17
 country: IN
 tags:
-  - quantum
   - python
   - visualization
+  - qaoa
 ---
 To [Utkarsh Azad](https://obliviateandsurrender.github.io/) and [Animesh Sinha](https://researchweb.iiit.ac.in/~animesh.sinha/home) to build a visualization tool called [qLEET](https://github.com/QLemma/qLEET) for exploring loss landscapes, expressibility, entangling capacity and trainability for noisy, parameterized quantum circuits.

--- a/src/content/grant/2022_Dynamic_QCNN.md
+++ b/src/content/grant/2022_Dynamic_QCNN.md
@@ -5,7 +5,8 @@ month: 5
 day: 5
 country: ZA
 tags:
-  - quantum CNN
   - python
+  - machine learning
+
 ---
  To **Matt Lourens**, to develop [Dynamic QCNN](https://github.com/matt-lourens/dynamic-qcnn), a tool to generate quantum convolutional neural network models programmatically.

--- a/src/content/grant/2022_HODL.md
+++ b/src/content/grant/2022_HODL.md
@@ -5,8 +5,8 @@ month: 3
 day: 28
 country: IE
 tags:
-  - OpenQasm
-  - QIR
-  - Quantum
+  - openqasm
+  - qir
+  - programming language
 ---
 To [Ayush Tambde](https://twitter.com/atamb_), to develop a Higher-Level Oracle Description Language (HODL), so that the compiler can interoperate with other frameworks/languages (OpenQASM, QIR). [arXiv](https://arxiv.org/abs/2110.12487)

--- a/src/content/grant/2022_The_QIR_Book.md
+++ b/src/content/grant/2022_The_QIR_Book.md
@@ -5,6 +5,7 @@ month: 9
 day: 26
 country: US
 tags:
-  - Quantum Education
+  - education
+  - textbook
 ---
 To **Paria Naghavi** to add code, visualizations, and conceptual content to the QIR Book, to build knowledge bridges for incoming users to the ecosystem.

--- a/src/content/grant/2022_Unicorn.md
+++ b/src/content/grant/2022_Unicorn.md
@@ -8,5 +8,6 @@ tags:
   - rust
   - quantum algorithms
   - classical algorithms
+  - verification
 ---
 To **[Stefanie Muroya Lei](https://twitter.com/SMuroyaLei)** and **[Christoph Kirsch](https://twitter.com/christophkirsch)**, to develop develop QUARC within the [Unicorn](https://github.com/cksystemsgroup/unicorn) framework, a bounded model checking that verifies classical programs using the best classical and quantum algorithms.

--- a/src/content/grant/2022_VQA_with_error_mitigation.md
+++ b/src/content/grant/2022_VQA_with_error_mitigation.md
@@ -5,8 +5,8 @@ month: 6
 day: 29
 country: US
 tags:
-  - quantum algorithms
   - python
+  - quantum algorithms
   - VQA
 ---
 To **Haoxiang Wang** and **Min Li**, to develop a high-level API for variational quantum algorithm (VQA) training with quantum error mitigation.

--- a/src/content/grant/2022_VQA_with_error_mitigation.md
+++ b/src/content/grant/2022_VQA_with_error_mitigation.md
@@ -5,7 +5,8 @@ month: 6
 day: 29
 country: US
 tags:
-  - quantum algorithm
+  - quantum algorithms
   - python
+  - VQA
 ---
 To **Haoxiang Wang** and **Min Li**, to develop a high-level API for variational quantum algorithm (VQA) training with quantum error mitigation.

--- a/src/content/grant/2022_guide_to_QEC.md
+++ b/src/content/grant/2022_guide_to_QEC.md
@@ -1,11 +1,12 @@
 ---
-name: "Guide to QEC" 
+name: "Guide to QEC"
 year: 2022
 month: 9
 day: 26
 country: CA
 tags:
-  - QEC
-  - Quantum Education
+  - error correction
+  - education
+  - texbook
 ---
 To **[Abdullah Khalid](https://twitter.com/abdullahkhalids)** to write a methods focused **[guide to quantum error correction](https://abdullahkhalid.com/qecft/)**.

--- a/src/content/grant/2023_Graphix.md
+++ b/src/content/grant/2023_Graphix.md
@@ -8,5 +8,6 @@ tags:
   - python
   - simulator
   - measurement-based qc
+  - photonics
 ---
 To **Shinichi Sunami and Masato Fukushima** to develop **[Graphix](https://github.com/TeamGraphix/graphix)**, an open-source library to optimize and simulate measurement-based quantum computing.

--- a/src/content/grant/2023_Graphix.md
+++ b/src/content/grant/2023_Graphix.md
@@ -6,7 +6,7 @@ day: 23
 country: GB, JP
 tags:
   - python
-  - Quantum 
-  - simulation
+  - simulator
+  - measurement-based qc
 ---
 To **Shinichi Sunami and Masato Fukushima** to develop **[Graphix](https://github.com/TeamGraphix/graphix)**, an open-source library to optimize and simulate measurement-based quantum computing.

--- a/src/content/grant/2023_H-Hat.md
+++ b/src/content/grant/2023_H-Hat.md
@@ -6,7 +6,7 @@ day: 3
 country: NL
 tags:
   - python
-  - quantum language
+  - programming language
 ---
 
 To **[Eduardo Maschio](https://www.linkedin.com/in/eduardomaschio)** to develop **[H-Hat](https://github.com/hhat-lang/hhat_lang)**, a quantum programming language made for developers.

--- a/src/content/grant/2023_HierarQcal.md
+++ b/src/content/grant/2023_HierarQcal.md
@@ -5,7 +5,9 @@ month: 2
 day: 27
 country: ZA
 tags:
-  - machine learning
   - python
+  - machine learning
+  - quantum circuits
+  - follow-up grant
 ---
 To **Matt Lourens**, to further develop [HierarQcal](https://github.com/matt-lourens/hierarqcal), a tool to simplify the generation of custom quantum circuits for neural architecture search.

--- a/src/content/grant/2023_HierarQcal.md
+++ b/src/content/grant/2023_HierarQcal.md
@@ -5,7 +5,7 @@ month: 2
 day: 27
 country: ZA
 tags:
-  - quantum CNN
+  - machine learning
   - python
 ---
 To **Matt Lourens**, to further develop [HierarQcal](https://github.com/matt-lourens/hierarqcal), a tool to simplify the generation of custom quantum circuits for neural architecture search.

--- a/src/content/grant/2023_MCTDH-X.md
+++ b/src/content/grant/2023_MCTDH-X.md
@@ -8,5 +8,6 @@ tags:
   - workshop
   - fortran
   - cold atoms
+  - many-body physics
 ---
 To **[Miriam Büttner, Sunayana Dutta, Paolo Molignini, Rui Lin, Camille Lévêque, Axel Lode](http://ultracold.org/menu/)** to organize a software developer workshop for the numerical simulation of ultracold quantum many-body systems **[MCTDH-X](https://gitlab.com/the-mctdh-x-repository/mctdh-x-releases), <a href="../../assets/MCTDH-X-Report.pdf" target="_blank">workshop report</a>**

--- a/src/content/grant/2023_MCTDH-X.md
+++ b/src/content/grant/2023_MCTDH-X.md
@@ -5,7 +5,8 @@ month: 4
 day: 3
 country: DE
 tags:
-  - quantum
-  - software 
+  - workshop
+  - fortran
+  - cold atoms
 ---
 To **[Miriam Büttner, Sunayana Dutta, Paolo Molignini, Rui Lin, Camille Lévêque, Axel Lode](http://ultracold.org/menu/)** to organize a software developer workshop for the numerical simulation of ultracold quantum many-body systems **[MCTDH-X](https://gitlab.com/the-mctdh-x-repository/mctdh-x-releases), <a href="../../assets/MCTDH-X-Report.pdf" target="_blank">workshop report</a>**

--- a/src/content/grant/2023_NFnet.md
+++ b/src/content/grant/2023_NFnet.md
@@ -5,7 +5,7 @@ month: 2
 day: 27
 country: US
 tags:
-  - quantum systems
+  - simulator
   - python
 ---
 To **Pengyuan (Bill) Zhai and Susanne Yelin** to develop **[NFNet](https://github.com/BILLYZZ/NFNet)**, a non-interacting fermion simulation network for large-scale quantum systems. [arXiv](https://arxiv.org/abs/2212.05779)

--- a/src/content/grant/2023_NFnet.md
+++ b/src/content/grant/2023_NFnet.md
@@ -7,5 +7,6 @@ country: US
 tags:
   - simulator
   - python
+  - many-body physics
 ---
 To **Pengyuan (Bill) Zhai and Susanne Yelin** to develop **[NFNet](https://github.com/BILLYZZ/NFNet)**, a non-interacting fermion simulation network for large-scale quantum systems. [arXiv](https://arxiv.org/abs/2212.05779)

--- a/src/content/grant/2023_OpenQuantum.md
+++ b/src/content/grant/2023_OpenQuantum.md
@@ -5,9 +5,9 @@ month: 10
 day: 23
 country: US
 tags:
-  - quantum education
+  - education
   - physics
   - open hardware
-  - quantum
+  - education
 ---
 To **Max Shirokawa Aalto** to further develop **[OpenQuantum](https://open-quantum.org/)**, a blueprint for a magneto-optical trap that open-sources high-quality CAD files, electronic schematics, control firmware and assembly instructions along with teaching materials to create a much-needed educational platform for quantum science and engineering.

--- a/src/content/grant/2023_Optimization_problems_in_OpenQAOA.md
+++ b/src/content/grant/2023_Optimization_problems_in_OpenQAOA.md
@@ -6,7 +6,7 @@ day: 23
 country: DE
 tags:
   - python
-  - Quantum Optimization
+  - optimization
 ---
 
 To **[Alejandro Montanez-Barrera](https://www.linkedin.com/in/alejandromontanez/)** to simplify benchmarking of optimization problems in **[OpenQAOA](https://github.com/entropicalabs/openqaoa/pull/71)**. Link to the [arXiv](https://arxiv.org/abs/2211.13914)

--- a/src/content/grant/2023_QHDOPT.md
+++ b/src/content/grant/2023_QHDOPT.md
@@ -5,8 +5,8 @@ month: 6
 day: 26
 country: US
 tags:
-  - gradient descent
-  - quantum
+  - hamiltonian
+  - optimization
   - python
 ---
 

--- a/src/content/grant/2023_Qast.md
+++ b/src/content/grant/2023_Qast.md
@@ -6,7 +6,6 @@ day: 23
 country: SG
 tags:
   - simulator
-  - software
   - finance
 ---
 To [**Michael Hellman**](https://www.linkedin.com/in/mhellman15/) to further develop **Qast (Quantum Asset Simulation Toolkit)**, a library that includes both common quantum representations of standard financial notation and classical assets.

--- a/src/content/grant/2023_QlassKit.md
+++ b/src/content/grant/2023_QlassKit.md
@@ -7,6 +7,5 @@ country: IT
 tags:
   - python
   - classical algorithms
-  - software
 ---
 To **Davide Gessa** to further develop **[QlassKit](https://github.com/dakk/qlasskit)**, a Python library that allows developers to write classical algorithms in Python and translate them into unitary operators for use in quantum circuits.

--- a/src/content/grant/2023_QuTritium.md
+++ b/src/content/grant/2023_QuTritium.md
@@ -6,7 +6,6 @@ day: 24
 country: VN
 tags:
   - python
-  - quantum
   - qiskit
 ---
 To **Son Pham and Tien Nguyen** to develop **[QuTritium](https://github.com/spham1611/qutritium)**, a Python package that helps automate the calibration process and extends the functionality of the Qiskit package in a qutrit system.

--- a/src/content/grant/2023_Strategic_partnership_events_in.md
+++ b/src/content/grant/2023_Strategic_partnership_events_in.md
@@ -5,7 +5,7 @@ month: 4
 day: 3
 country: LV
 tags:
- - quantum education
+ - education
 ---
 
 To **[Abuzer Yakaryilmaz](http://ultracold.org/menu/)** to foster **[QWorld](https://qworld.net/)**'s activites, including QScience Days and QCourses.

--- a/src/content/grant/2023_Timeline_Debugger_for_Qiskit.md
+++ b/src/content/grant/2023_Timeline_Debugger_for_Qiskit.md
@@ -6,7 +6,7 @@ day: 27
 country: IN
 tags:
   - qiskit
-  - quantum
+  - debugger
   - python
 ---
 To **[Harshit Gupta](https://www.linkedin.com/in/thegupta2012/)** to further develop a [timeline debugger](https://github.com/TheGupta2012/qiskit-timeline-debugger) for the Qiskit transpiler.

--- a/src/content/grant/2023_TorchQuantum.md
+++ b/src/content/grant/2023_TorchQuantum.md
@@ -7,6 +7,6 @@ country: US
 tags:
   - python
   - simulator
-  - quantum
+  - pytorch
 ---
 To **Hanrui Wang** to further develop **[TorchQuantum](https://github.com/mit-han-lab/torchquantum)**, a Quantum classical simulation framework based on PyTorch.

--- a/src/content/grant/2023_bgls.md
+++ b/src/content/grant/2023_bgls.md
@@ -7,6 +7,6 @@ country: CH
 tags:
   - quantum algorithms
   - simulation
-  - MPS
+  - tensor networks
 ---
 To **Alex Shapiro and Ryan LaRose** to further develop **[bgls](https://github.com/asciineuron/bgls)**, an implementation of the gate-by-gate sampling algorithm of Bravyi, Gosset and Liu (2022) for classically simulating quantum circuit measurement.

--- a/src/content/grant/2023_labscript_qc.md
+++ b/src/content/grant/2023_labscript_qc.md
@@ -6,8 +6,7 @@ day: 25
 country: DE
 tags:
   - cold atoms
-  - software
-  - quantum
+  - open hardware
 ---
 
 To **Fred Jendrzejewski** to develop an SDK that allows cold atom research groups to make their experiments more accessible. The project has been merged with the **[sqooler](https://github.com/Alqor-UG/sqooler)** package such that theorists and experimentalists have a common framework. Beta testers are welcome to test examples for [hardware control](https://github.com/Alqor-UG/labscript-qc-example) and [simulators](https://github.com/Alqor-UG/sqooler-example).

--- a/src/content/grant/2023_lambdaq.md
+++ b/src/content/grant/2023_lambdaq.md
@@ -6,6 +6,7 @@ day: 24
 country: RO
 tags:
   - haskell
+  - programming language
 ---
 
 To **Radu Marginean** to further develop **[lambdaQ](https://github.com/radumarg/lambdaQ)**, a functional programming language for quantum computing based on Haskell.

--- a/src/content/grant/2023_mdopt.md
+++ b/src/content/grant/2023_mdopt.md
@@ -5,7 +5,7 @@ month: 7
 day: 24
 country: CA
 tags:
-  - quantum error correction
+  - error correction
   - tensor network
   - python
 ---

--- a/src/content/grant/2023_qiskit_qulacs.md
+++ b/src/content/grant/2023_qiskit_qulacs.md
@@ -5,8 +5,8 @@ month: 8
 day: 28
 country: IN
 tags:
-  - Qiskit
+  - qiskit
   - simulator
-  - QML
+  - machine learning
 ---
 To **Gopal Ramesh Dahale** to further develop **[Qiskit-Qulacs](https://github.com/Gopal-Dahale/qiskit-qulacs)**, a plugin using Qulacs as a backend for Qiskit circuits.

--- a/src/content/grant/2023_stac.md
+++ b/src/content/grant/2023_stac.md
@@ -5,7 +5,7 @@ month: 4
 day: 3
 country: CA
 tags:
-  - quantum
+  - error correction
   - python
 ---
 To **[Abdullah Khalid](https://abdullahkhalid.com/)** to further develop **[stac](https://github.com/abdullahkhalids/stac)**, a circuit library optimized for building fault-tolerant circuits for stabilizer codes.

--- a/src/content/grant/2023_toqito.md
+++ b/src/content/grant/2023_toqito.md
@@ -6,6 +6,7 @@ day: 25
 country: US
 tags:
   - python
-  - software
+  - toqito
+  - follow-up grant
 ---
 To **Purva Thakre** to grow **[Toqito](https://github.com/purva-thakre)**, toward a mature open-source project and utilize it for further research in unextendible product bases.

--- a/src/content/grant/2024_<Quantum|Chamitas>.md
+++ b/src/content/grant/2024_<Quantum|Chamitas>.md
@@ -5,8 +5,6 @@ month: 1
 day: 24
 country: FR,VE
 tags:
-  - quantum education
-  - physics
-  - quantum
+  - education
 ---
 To **Dafne Carolina Arias Perdomo** to further develop **[<Quantum|Chamitas>](https://drcarolinaperdomo.com/empowering-young-venezuelan-girls-in-quantum-education/)**, a pioneering initiative focusing on accessible, high-quality quantum education in both Venezuela and France for girls in STEM.

--- a/src/content/grant/2024_An entanglement toolbox for t-doped stabilizer states beyond the classical simulability barrier.md
+++ b/src/content/grant/2024_An entanglement toolbox for t-doped stabilizer states beyond the classical simulability barrier.md
@@ -5,8 +5,8 @@ month: 2
 day: 26
 country: US
 tags:
-  - t-doped states
+  - error correction
   - simulation
-  - quantum
+  - python
 ---
 To **Andi Gu, [Lorenzo Leone](https://twitter.com/lorenzo_leone_?lang=en), & Salvatore F.E. Oliviero** to further develop **An entanglement toolbox for t-doped stabilizer states beyond the classical simulability barrier**, a toolbox to equip researchers with theoretical tools and a Python framework to study t-doped states' entanglement efficiently

--- a/src/content/grant/2024_Error-agnostic_shadow_estimation.md
+++ b/src/content/grant/2024_Error-agnostic_shadow_estimation.md
@@ -5,7 +5,7 @@ month: 4
 day: 22
 country: DE, NL
 tags:
-  - Error Mitigation
-  - Python
+  - error mitigation
+  - python
 ---
 To **[Markus Heinrich](https://www.markus-heinrich.eu/), [Jonas Helsen](https://www.linkedin.com/in/jonas-helsen-026506b4/)** and **Ingo Roth** to further develop **Error-agnostic shadow estimation**, to show that logarithmic-depth random circuits are sufficient to estimate expectation values of a large class of global observables.

--- a/src/content/grant/2024_GQuantum_Education.md
+++ b/src/content/grant/2024_GQuantum_Education.md
@@ -5,6 +5,6 @@ month: 6
 day: 03
 country: GH
 tags:
-  - Quantum Education
+  - education
 ---
 To **[Dorcas Attuabea Addo](http://linkedin.com/in/dorcas-attuabea-addo), [Henry Martin](http://linkedin.com/in/henry-martin-phd-54704869), [Peter Nimbe](http://linkedin.com/in/dr-peter-nimbe-945b1b32)** to further develop **GQuantum Education**, a quantum education initiative based in Ghana.

--- a/src/content/grant/2024_Hypergraph_MWPF_Decoder.md
+++ b/src/content/grant/2024_Hypergraph_MWPF_Decoder.md
@@ -5,6 +5,6 @@ month: 4
 day: 22
 country: US
 tags:
-  - QEC
+  - error correction
 ---
 To **Yue Wu** to further develop **[Hypergraph MWPF Decoder for QEC](https://pypi.org/project/mwpf/)**, creating a new decoder that can decode arbitrary qLDPC codes and establish a programming framework that allows one to implement graph-based decoders easily.

--- a/src/content/grant/2024_Lie_Properties.md
+++ b/src/content/grant/2024_Lie_Properties.md
@@ -5,7 +5,7 @@ month: 6
 day: 24
 country: DE
 tags:
-  - Machine learning
-  - Algebra
+  - machine learning
+  - algebra
 ---
-To **Oxana Shaya** and **Konstantin Golovkin** to further develop **[Lie algebraic properties of quantum circuits](https://github.com/AmanieOxana/Lie_props)**, an implementation of functionalities that help with the understanding of the Lie algebra of a quantum circuit. 
+To **Oxana Shaya** and **Konstantin Golovkin** to further develop **[Lie algebraic properties of quantum circuits](https://github.com/AmanieOxana/Lie_props)**, an implementation of functionalities that help with the understanding of the Lie algebra of a quantum circuit.

--- a/src/content/grant/2024_MQT_Qudits.md
+++ b/src/content/grant/2024_MQT_Qudits.md
@@ -7,7 +7,7 @@ country: DE
 tags:
   - python
   - GPU
-  - Simulation
-  - HPC
+  - simulation
+  - hpc
 ---
 To **[Kevin Mato](https://www.linkedin.com/in/kevin-mato-quantum/)** to further develop **[MQT Qudits](https://github.com/cda-tum/mqt-qudits)**, a quantum open-source software framework for mixed-dimensional quantum computing.

--- a/src/content/grant/2024_Mitiq_QEC_Performance_Analysis.md
+++ b/src/content/grant/2024_Mitiq_QEC_Performance_Analysis.md
@@ -5,8 +5,8 @@ month: 4
 day: 24
 country: US
 tags:
-  - Mitiq
-  - QEM
-  - QEC
+  - mitiq
+  - error mitigation
+  - error correction
 ---
 To **Ella Carlander** and **Ruhee Nirodi** to further develop **[Overhead and Performance Analysis for Mitiq’s Quantum Error Mitigation Implementations](https://unitary.fund/posts/2024_capstone_uw/)**, a tool that can characterize overhead for different QEM methods and compare them.

--- a/src/content/grant/2024_Quantum_Arcade.md
+++ b/src/content/grant/2024_Quantum_Arcade.md
@@ -5,8 +5,7 @@ month: 6
 day: 24
 country: CA
 tags:
-  - Games
-  - Education
-  - Quantum
+  - games
+  - education
 ---
-To **[Timothy King](https://www.linkedin.com/in/temking/)** and **[Ella Meyer](https://www.linkedin.com/in/ella-meyer-6a887313a/)** to further develop **[Quantum Arcade](https://quantumalgorithmsinstitute-my.sharepoint.com/:p:/g/personal/timothy_king_quantumalgorithmsinstitute_ca/EdDQc-vYI3lOvFxdMwiBzcIBu4HZQWkYdogPLuqJrmpwJg?rtime=Zwsxb0qk3Eg)**, creating a landing page and currating existing quantum games as well as developing resources for new games to help teach quantum computing globally. 
+To **[Timothy King](https://www.linkedin.com/in/temking/)** and **[Ella Meyer](https://www.linkedin.com/in/ella-meyer-6a887313a/)** to further develop **[Quantum Arcade](https://quantumalgorithmsinstitute-my.sharepoint.com/:p:/g/personal/timothy_king_quantumalgorithmsinstitute_ca/EdDQc-vYI3lOvFxdMwiBzcIBu4HZQWkYdogPLuqJrmpwJg?rtime=Zwsxb0qk3Eg)**, creating a landing page and currating existing quantum games as well as developing resources for new games to help teach quantum computing globally.

--- a/src/content/grant/2024_TQEC.md
+++ b/src/content/grant/2024_TQEC.md
@@ -5,7 +5,6 @@ month: 2
 day: 26
 country: US
 tags:
-  - Quantum Error Correction
-  - Software
+  - error correction
 ---
 To **Sam Burdick** to further develop **["Topological Quantum Error Correction (TQEC)"](https://github.com/QCHackers/tqec)**, expanding an existing open-source TQEC service.

--- a/src/content/grant/2024_qubit-pulse.md
+++ b/src/content/grant/2024_qubit-pulse.md
@@ -5,8 +5,8 @@ month: 2
 day: 26
 country: US
 tags:
-  - Quantum Education
-  - Games
-  - Simulation
+  - education
+  - games
+  - simulation
 ---
-To **[Mattias Fitzpatrick](https://www.linkedin.com/in/mattias-fitzpatrick-8b53a9102/)** to further develop **[Qubit-Pulse: An educational qubit pulse engineering game](https://github.com/mvwf/qublitz)**, a pulse simulator game that takes in drive amplitudes as a function of time and produces the qubit state in the Bloch sphere to allow users to simulate different Hamiltonians and controls. 
+To **[Mattias Fitzpatrick](https://www.linkedin.com/in/mattias-fitzpatrick-8b53a9102/)** to further develop **[Qubit-Pulse: An educational qubit pulse engineering game](https://github.com/mvwf/qublitz)**, a pulse simulator game that takes in drive amplitudes as a function of time and produces the qubit state in the Bloch sphere to allow users to simulate different Hamiltonians and controls.

--- a/src/content/grant/Global_Expansion_QCoder.md
+++ b/src/content/grant/Global_Expansion_QCoder.md
@@ -5,7 +5,7 @@ month: 3
 day: 25
 country: JP
 tags:
-  - Games
-  - Quantum Education
+  - game
+  - education
 ---
 To **[Kein Yukiyoshi](https://www.linkedin.com/in/kein-yukiyoshi/), [Adam Siegel](https://www.linkedin.com/in/adam-siegel-89a795171/)** and **[Tyson Jones](https://www.linkedin.com/in/tysonrayjones/)** to further develop **[Global Expansion of QCoder](https://www.qcoder.jp/)**, a quantum programming contest platform.

--- a/src/content/grant/Holistic_ACL_model.md
+++ b/src/content/grant/Holistic_ACL_model.md
@@ -7,6 +7,6 @@ country: FR
 tags:
   - python
   - simulator
-  - quantum
+  - qutip
 ---
-To **Marin Girard** to further develop **[Holistic ACL model + decoherence notebooks using Qutip](https://github.com/MarinAndreGirard)**, to complement the current implementation of the ACL model in Qutip by making it holistic, including all the necessary tools to explore it as well as making it freely accessible on GitHub.
+To **Marin Girard** to further develop **[Holistic ACL model + decoherence notebooks using QuTiP](https://github.com/MarinAndreGirard)**, to complement the current implementation of the ACL model in Qutip by making it holistic, including all the necessary tools to explore it as well as making it freely accessible on GitHub.

--- a/src/content/grant/Integration_Zero-Noise_Extrapolation_Mitiq_OpenQAOA.md
+++ b/src/content/grant/Integration_Zero-Noise_Extrapolation_Mitiq_OpenQAOA.md
@@ -5,8 +5,8 @@ month: 3
 day: 25
 country: IT
 tags:
-  - Mitiq
-  - Error Mitigation
-  - Optimization
+  - mitiq
+  - error mitigation
+  - qaoa
 ---
 To **[Marco Venere](https://www.linkedin.com/in/marcovenere/), [Adriano Lusso](https://www.linkedin.com/in/adrianolusso/?locale=en_US), [Alberto Maldonado](https://www.linkedin.com/in/albertomaldonadoromo/)** and **[Victor Onofre](https://www.linkedin.com/in/victor-onofre-a9b1371a7/)** to develop **[Integration of Zero-Noise Extrapolation from Mitiq into OpenQAOA](https://github.com/victor-onofre/openqaoa/tree/dev)**, which will integrate Mitiq into OpenQAOA to allow error mitigation techniques to take place during the execution of the QAOA algorithm.

--- a/src/content/grant/Piccolo.jl.md
+++ b/src/content/grant/Piccolo.jl.md
@@ -7,5 +7,6 @@ country: US
 tags:
   - julia
   - optimal control
+  - follow-up grant
 ---
 To **Aaron Trowbridge** to further develop **[Piccolo.jl](https://github.com/aarontrowbridge/Piccolo.jl)**, releasing a 1.0 version that will further segment the code base, separating the backend solver interface code into a QuantumCollocationCore.jl package as well as make it easy for python users to use the quantum optimal control method.

--- a/src/content/grant/Piccolo.jl.md
+++ b/src/content/grant/Piccolo.jl.md
@@ -6,6 +6,6 @@ day: 03
 country: US
 tags:
   - julia
-  - optimization
+  - optimal control
 ---
 To **Aaron Trowbridge** to further develop **[Piccolo.jl](https://github.com/aarontrowbridge/Piccolo.jl)**, releasing a 1.0 version that will further segment the code base, separating the backend solver interface code into a QuantumCollocationCore.jl package as well as make it easy for python users to use the quantum optimal control method.


### PR DESCRIPTION
This pull request is an attempt at unifying and improving the current tags used for grants, so that the search filter can be more useful on the grants page. Some decisions I took include:
- removing too generic tags, such as "quantum" and "software"
- trying to include the programming language of a software project, such as "python", if applicable
-  come up with some standardization to unify tags (plural/singular), shortening them ("quantum education" --> "education") which led to some new tags emerging: 
   - "follow-up grant"
   - "qiskit", "qutip", "mitiq" etc. 
   - "programming language" for projects developing a new language; I wonder if "domain specific language" would be better, but thought the first option to be more intuitive
- use only lower case
- avoid acronyms; although on this I see there is a tradeoff. So I removed "QEC" and used "error correction" as much as possible