### PR TITLE
Add comment section to blog posts

### DIFF
--- a/src/components/Pages/Blog/PostComments.astro
+++ b/src/components/Pages/Blog/PostComments.astro
@@ -1,0 +1,17 @@
+<section class="giscus mx-auto mt-10 w-full"></section>
+
+<script src="https://giscus.app/client.js"
+        data-repo="unitaryfund/unitary.fund"
+        data-repo-id="MDEwOlJlcG9zaXRvcnkxMzg1MTY4Nzk="
+        data-category="Blog Post Comments"
+        data-category-id="DIC_kwDOCEGZj84CkWc_"
+        data-mapping="url"
+        data-strict="0"
+        data-reactions-enabled="1"
+        data-emit-metadata="0"
+        data-input-position="bottom"
+        data-theme="noborder_light"
+        data-lang="en"
+        crossorigin="anonymous"
+        async>
+</script>

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -2,6 +2,7 @@
 import Layout from '~/layouts/Layout.astro';
 import { getCollection, getEntry } from 'astro:content';
 import type { CollectionEntry } from 'astro:content';
+import PostComments from '~/components/Pages/Blog/PostComments.astro';
 
 export async function getStaticPaths() {
   const blogEntries = await getCollection('blog');
@@ -49,5 +50,6 @@ const { title, author, day, month, year } = entry.data;
         <Content />
       </div>
     </article>
+    <PostComments />
   </div>
 </Layout>


### PR DESCRIPTION
Implemented via https://giscus.app/

Comments end up in Github Discussions of this repo at https://github.com/unitaryfund/unitary.fund/discussions/categories/blog-post-comments

It looks like 👇

![Screenshot 2024-11-17 at 19 45 20](https://github.com/user-attachments/assets/9a80231c-69a6-4bed-afbf-dfbda3c6c3b6)
